### PR TITLE
Newer version with full RHEL/CentOS 7 support added

### DIFF
--- a/SOURCES/consul.firewalld
+++ b/SOURCES/consul.firewalld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>consul-server</short>
+  <description>Consul - A service mesh solution. Port used by servers to handle incoming requests from other agents.</description>
+  <port protocol="tcp" port="8300"/>
+</service>
+<service>
+  <short>consul-agent</short>
+  <description>Consul - A service mesh solution. Port used by agents to handle gossip in the LAN.</description>
+  <port protocol="tcp" port="8301"/>
+  <port protocol="udp" port="8301"/>
+</service>
+<service>
+  <short>consul-server-wan</short>
+  <description>Consul - A service mesh solution. Port used by servers to gossip over the LAN and WAN to other servers.</description>
+  <port protocol="tcp" port="8302"/>
+  <port protocol="udp" port="8302"/>
+</service>
+<service>
+  <short>consul-http</short>
+  <description>Consul - A service mesh solution. Port used by clients to talk to the HTTP API.</description>
+  <port protocol="tcp" port="8500"/>
+</service>
+<service>
+  <short>consul-dns</short>
+  <description>Consul - A service mesh solution. Port used by clients to talk to the DNS service.</description>
+  <port protocol="tcp" port="8600"/>
+  <port protocol="udp" port="8600"/>
+</service>

--- a/SOURCES/consul.hcl
+++ b/SOURCES/consul.hcl
@@ -1,0 +1,4 @@
+datacenter = "local"
+data_dir = "/var/lib/consul"
+log_level = "INFO"
+encrypt = "CHANGE_ME_PLEASE"

--- a/SOURCES/consul.init
+++ b/SOURCES/consul.init
@@ -26,7 +26,7 @@ if [ -f /etc/sysconfig/consul ]; then
 fi
 
 consul_bin=${CONSUL_BIN-/usr/sbin/consul}
-consul_config_file=${CONSUL_CONFIG_FILE-/etc/consul/consul.json}
+consul_config_dir=${CONSUL_CONFIG_DIR-/etc/consul}
 consul_log_file=${CONSUL_LOG_FILE-/var/log/consul/consul.log}
 consul_pid_file=${CONSUL_PID_FILE-/var/run/consul/consul.pid}
 consul_user=${CONSUL_USER-consul}
@@ -39,7 +39,7 @@ start() {
   daemon \
     --pidfile=${consul_pid_file} \
     --user=${consul_user} \
-    "{ ${consul_bin} agent -server -config-file ${consul_config_file} ${CONSUL_OPTS} \
+    "{ ${consul_bin} agent -config-dir ${consul_config_dir} ${CONSUL_OPTS} \
                            >> ${consul_log_file} 2>&1 & }; echo \$! >| ${consul_pid_file}" 
   RETVAL=$?
   [ $RETVAL = 0 ] && success
@@ -50,6 +50,15 @@ start() {
 stop() {
   echo -n $"Stopping $prog: "
   killproc -p ${consul_pid_file}
+  RETVAL=$?
+  [ $RETVAL = 0 ] && success
+  [ $RETVAL != 0 ] && failure
+  echo
+}
+
+reload() {
+  echo -n $"Reloading $prog: "
+  ${consul_bin} reload
   RETVAL=$?
   [ $RETVAL = 0 ] && success
   [ $RETVAL != 0 ] && failure
@@ -68,8 +77,11 @@ case "$1" in
     stop
     start
     ;;
+  reload)
+    reload
+    ;;
   *)
-    echo $"Usage: $prog {start|stop|restart}"
+    echo $"Usage: $prog {start|stop|restart|reload}"
     RETVAL=2
 esac
 

--- a/SOURCES/consul.json
+++ b/SOURCES/consul.json
@@ -1,8 +1,0 @@
-{
-  "datacenter": "local",
-  "data_dir": "/var/lib/consul",
-  "log_level": "INFO",
-  "node_name": "localhost",
-  "server": true,
-  "ui": false
-}

--- a/SOURCES/consul.service
+++ b/SOURCES/consul.service
@@ -1,0 +1,18 @@
+[Unit]
+Description="Consul - A service mesh solution"
+Documentation=https://www.consul.io/
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+User=consul
+Group=consul
+EnvironmentFile=/etc/sysconfig/consul
+ExecStart=/usr/sbin/consul agent -config-dir ${CONSUL_CONFIG_DIR} ${CONSUL_OPTS}
+ExecReload=/usr/sbin/consul reload
+KillMode=process
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,14 +1,14 @@
 # Path to consul binary
 #CONSUL_BIN=/usr/sbin/consul
 
-# Config file for consul agent
-#CONSUL_CONFIG_FILE=/etc/consul/consul.json
+# Config dir for consul agent
+CONSUL_CONFIG_DIR=/etc/consul
 
 # Log file for consul agent
 #CONSUL_LOG_FILE=/var/log/consul/consul.log
 
 # Additional opts to pass to consul
-#CONSUL_OPTS=""
+CONSUL_OPTS=""
 
 # Pid file for consul agent
 #CONSUL_PID_FILE=/var/run/consul/consul.pid

--- a/SOURCES/consul.tmpfiles
+++ b/SOURCES/consul.tmpfiles
@@ -1,0 +1,1 @@
+/run/consul  755 consul consul

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,10 +1,9 @@
 %define debug_package %{nil}
 
 Name:		consul
-Version:	1.0.6
+Version:	1.4.4
 Release:	1%{dist}
-Summary:	A tool for service discovery
-Group:		Applications/Internet
+Summary:	A service mesh solution
 License:	Mozilla Public License 2.0
 URL:		https://www.consul.io
 %ifarch x86_64 amd64
@@ -12,15 +11,25 @@ Source0:        https://releases.hashicorp.com/%{name}/%{version}/%{name}_%{vers
 %else
 Source0:        https://releases.hashicorp.com/%{name}/%{version}/%{name}_%{version}_linux_386.zip
 %endif
-Source1:        %{name}.json
+Source1:        %{name}.hcl
 Source2:        %{name}.init
 Source3:        %{name}.logrotate
 Source4:        %{name}.sysconfig
+Source5:        %{name}.service
+Source6:        %{name}.tmpfiles
+Source7:        %{name}.firewalld
+%if 0%{?rhel} >= 7
+Requires:         firewalld-filesystem
+Requires(post):   systemd-units
+Requires(preun):  systemd-units
+Requires(postun): systemd-units
+BuildRequires:    systemd-units
+%endif
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
-Consul is a tool for service discovery and configuration. Consul is distributed, 
-highly available, and extremely scalable.
+Consul is a tool for service discovery and configuration.
+Consul is distributed, highly available, and extremely scalable.
 
 %prep
 %setup -c
@@ -29,13 +38,27 @@ highly available, and extremely scalable.
 %{__install} -d -m 0755 %{buildroot}%{_sbindir} \
                         %{buildroot}%{_sysconfdir}/%{name} \
                         %{buildroot}%{_sysconfdir}/logrotate.d \
-                        %{buildroot}%{_sysconfdir}/rc.d/init.d \
                         %{buildroot}%{_sysconfdir}/sysconfig \
-                        %{buildroot}%{_localstatedir}/{lib,log,run}/%{name}
+                        %{buildroot}%{_localstatedir}/{lib,log}/%{name}
+%if 0%{?rhel} < 7
+%{__install} -d -m 0755 %{buildroot}%{_sysconfdir}/rc.d/init.d \
+                        %{buildroot}%{_localstatedir}/run/%{name}
+%else
+%{__install} -d -m 0755 %{buildroot}%{_unitdir} \
+                        %{buildroot}%{_rundir}/%{name} \
+                        %{buildroot}%{_tmpfilesdir} \
+                        %{buildroot}%{_prefix}/lib/firewalld/services
+%endif
          
 %{__install} -m 0755 %{name} %{buildroot}%{_sbindir}
 %{__install} -m 0600 %{SOURCE1} %{buildroot}%{_sysconfdir}/%{name}
+%if 0%{?rhel} < 7
 %{__install} -m 0755 %{SOURCE2} %{buildroot}%{_sysconfdir}/rc.d/init.d/%{name}
+%else
+%{__install} -m 0644 %{SOURCE5} %{buildroot}%{_unitdir}/%{name}.service
+%{__install} -m 0644 %{SOURCE6} %{buildroot}%{_tmpfilesdir}/%{name}.conf
+%{__install} -m 0644 %{SOURCE7} %{buildroot}%{_prefix}/lib/firewalld/services/%{name}.xml
+%endif
 %{__install} -m 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 %{__install} -m 0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
@@ -43,14 +66,29 @@ highly available, and extremely scalable.
 getent group %{name} >/dev/null || groupadd -r %{name}
 getent passwd %{name} >/dev/null || \
   useradd -r -g %{name} -s /sbin/nologin \
-    -d %{_localstatedir}/lib/%{name} -c "RPM Created Consul User" %{name}
+    -d %{_localstatedir}/lib/%{name} -c "Consul User" %{name}
 
 %post
-/sbin/chkconfig --add %{name}
+%if 0%{?systemd_post:1}
+    %systemd_post %{name}.service
+    %firewalld_reload
+    /usr/bin/systemd-tmpfiles --create %{_tmpfilesdir}/%{name}.conf
+%else
+    /sbin/chkconfig --add %{name}
+%endif
 
 %preun
-/sbin/service %{name} stop > /dev/null 2>&1
-/sbin/chkconfig --del %{name}
+%if 0%{?systemd_preun:1}
+    %systemd_preun %{name}.service
+%else
+    /sbin/service %{name} stop > /dev/null 2>&1
+    /sbin/chkconfig --del %{name}
+%endif
+
+%postun
+%if 0%{?systemd_postun:1}
+    %systemd_postun %{name}.service
+%endif
 
 %clean
 rm -rf %{buildroot}
@@ -59,14 +97,31 @@ rm -rf %{buildroot}
 %defattr(-,consul,consul,-)
 %attr(-,root,root) %{_sbindir}/%{name}
 %attr(-,root,root) %{_sysconfdir}/logrotate.d/%{name}
+%if 0%{?rhel} < 7
 %attr(-,root,root) %{_sysconfdir}/rc.d/init.d/%{name}
+%else
+%attr(-,root,root) %{_unitdir}/%{name}.service
+%attr(-,root,root) %{_tmpfilesdir}/%{name}.conf
+%attr(-,root,root) %{_prefix}/lib/firewalld/services/%{name}.xml
+%endif
 %attr(-,root,root) %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.*
 %{_localstatedir}/lib/%{name}
 %{_localstatedir}/log/%{name}
+%if 0%{?rhel} >= 7
+%ghost %attr(755,consul,consul) %{_rundir}/%{name}
+%else
 %{_localstatedir}/run/%{name}
+%endif
 
 %changelog
+* Tue Apr 02 2019 Giuseppe Ragusa <giuseppe.ragusa@fastmail.fm> - 1.4.4-1
+- Update to version 1.4.4
+- Modified spec to properly support CentOS/RHEL 7
+- Converted strategy from config file to config dir
+- Converted sample config file to HCL
+- Small uniformity mods
+
 * Sun Mar 25 2018 Taylor Kimball <tkimball@linuxhq.org> - 1.0.6-1
 - Update to version 1.0.6
 


### PR DESCRIPTION
- Updated to version 1.4.4
- Modified spec to properly support CentOS/RHEL 7:
  * Added firewalld XML services definition
  * Added systemd service unit file
  * Added tmpfiles configuration
- Converted configuration strategy from config file to config dir
- Converted sample config file from JSON to HCL
- Added reload action to SysV init script
- Small spec style mods